### PR TITLE
fix: Remove dconf theme preference

### DIFF
--- a/etc/dconf/db/local.d/01-custom
+++ b/etc/dconf/db/local.d/01-custom
@@ -8,7 +8,6 @@ cursor-theme='Yaru'
 icon-theme='Yaru'
 gtk-theme='Yaru'
 font-antialiasing='rgba'
-color-scheme='prefer-dark'
 
 [org/gnome/shell/extensions/dash-to-dock]
 dock-fixed=false


### PR DESCRIPTION
Removes the preferred theme option in dconf.  This is causing some issues since the option is often overwritten, which causes the entire dconf file to not be updated.
The preferred theme is asked during the initial setup anyway.