### PR TITLE
fix: Disable GNOME Shell Extension version validation

### DIFF
--- a/etc/dconf/db/local.d/01-custom
+++ b/etc/dconf/db/local.d/01-custom
@@ -1,6 +1,7 @@
 [org/gnome/shell]
 favorite-apps = ['org.mozilla.firefox.desktop', 'org.mozilla.Thunderbird.desktop', 'org.gnome.Nautilus.desktop', 'com.slack.Slack', 'org.gnome.Software.desktop', 'yelp.desktop']
 enabled-extensions = ['appindicatorsupport@rgcjonas.gmail.com', 'dash-to-dock@micxgx.gmail.com','blur-my-shell@aunetx']
+disable-extension-version-validation = true
 
 [org/gnome/desktop/interface]
 enable-hot-corners=false


### PR DESCRIPTION
The `blur-my-shell` extension fails to be enabled in GNOME 44 (Fedora 38) since it's not been verified against this version.
This PR disables the version validation since IMO it's not very useful.  If an extension doesn't work in GNOME 44, it will just not be enabled, and be as if it was never installed.  
We might as well force enable everything and see what works.