### PR TITLE
fix: Remove podman default configuration

### DIFF
--- a/base/etc/containers/containers.conf
+++ b/base/etc/containers/containers.conf
@@ -1,3 +1,0 @@
-[containers]
-label = false
-userns = "keep-id"


### PR DESCRIPTION
The default configuration prevented NVIDIA GPUs from working inside containers.  
We can add the config to each devcontainer, so it's not a big deal.